### PR TITLE
Back to jQuery 1.8.0.

### DIFF
--- a/activity_streams/AddActivity/gadget.xml
+++ b/activity_streams/AddActivity/gadget.xml
@@ -22,7 +22,7 @@ body {
 }
 </style>
 <link rel="stylesheet" href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.min.css" />
-<script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
+<script src="http://code.jquery.com/jquery-1.8.0.min.js"></script>
 <script src="http://code.jquery.com/ui/1.10.3/jquery-ui.min.js"></script>
 
 <script type="text/javascript">

--- a/activity_streams/Timeline/gadget.xml
+++ b/activity_streams/Timeline/gadget.xml
@@ -56,7 +56,7 @@ body {
   height: 0; overflow: hidden;
 }
 </style>
-<script type="text/javascript" src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
+<script type="text/javascript" src="http://code.jquery.com/jquery-1.8.0.min.js"></script>
 <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.1.0/moment.min.js"></script>
 <script type="text/javascript">
 // New namespace (prevent conflicts with the rest of the page)


### PR DESCRIPTION
@voz I just noticed that using jQuery 1.9 causes some display bugs in the AddActivity gadget. Back to 1.8.0 solves everything.
