### PR TITLE
-fixes the bug where phase names containing symbols were causing an ILS ...

### DIFF
--- a/prod/ils_metawidget/app.js
+++ b/prod/ils_metawidget/app.js
@@ -195,11 +195,11 @@ var build_tabs = function(subspaces) {
   _.each(subspaces, function(item) {
     var ils_tab = $("<li></li>");
     var tab_link = $("<a></a>").text(item.displayName);
-    tab_link.attr("href", "#" + item.displayName.replace(' ','_'));
+    tab_link.attr("href", "#" + item.id);
     ils_tab.append(tab_link);
     ils_cycle_tabs.append(ils_tab);
     var phase = $("<div></div>").addClass("tab-pane");
-    phase.attr("id", item.displayName.replace(' ','_'));
+    phase.attr("id", item.id);
     var phase_description = $("<div></div>").append(item.description);
     phase.append(phase_description);
     var phase_content = $("<div></div>");


### PR DESCRIPTION
...no to load. Now using space ids to generate the links instead of phase names.
