### PR TITLE
ILS Title Length fix

### DIFF
--- a/prod/ils_metawidget_graaspeu/app.js
+++ b/prod/ils_metawidget_graaspeu/app.js
@@ -102,6 +102,8 @@ var initialize_ils = function() {
          app.backgroundImage=data.currentSpace.background.image?data.currentSpace.background.image:"";
          img = new Image();
          img.src=item.background.image;
+         img_default= new Image();
+         img_default.src="http://graasp.epfl.ch/gadget/prod/ils_metawidget_graaspeu/bg.jpg";
      }catch(err){
          app.backgroundImage="";
      }
@@ -121,11 +123,7 @@ var initialize_ils = function() {
     if (currentSpace) {
       ILS.name=currentSpace.displayName;
       ILS.id=currentSpace.id;
-      if(ILS.name.length>35){
-        $("#title").append(ILS.name.substring(0,34)+"...");
-      }else{
         $("#title").append(ILS.name);
-      }
       if (currentSpace.description.replace(/[\s|&nbsp;]+/gi,'') !="" && $(currentSpace.description).text()!=""){ // when there is a valid description
         $("#description").append(currentSpace.description);
       }

--- a/prod/ils_metawidget_graaspeu/custom.css
+++ b/prod/ils_metawidget_graaspeu/custom.css
@@ -266,6 +266,11 @@ p {
     line-height:42px;
     color:#ffffff;
     cursor: pointer;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    width:100%;
+    display: block;
 }
 
 #hello_msg {
@@ -525,7 +530,7 @@ iframe{
     margin-left: 0;
     line-height: 2.5em;
     word-break: break-word;
-    width: 70%;
+    width: 80%;
     float:left;
 }
 


### PR DESCRIPTION
- The ILS title expands up to 80% of the top bar. After that it gets clipped with ellipsis (...)
- The default background image is also cached
