### PR TITLE
Fixing sockets and cleaning

### DIFF
--- a/activity_streams/onlineUsers/onlineUsers.css
+++ b/activity_streams/onlineUsers/onlineUsers.css
@@ -92,7 +92,7 @@ body {
   margin: 0px;
   padding: 0px;
   font-size: 30px;
-  padding: 4px;
+  padding: 3px 4px 5px 4px;
   text-align: center;
   font-family: 'Helvetica Neue', 'HelveticaNeue', Helvetica, Arial, sans-serif;
   font-weight: 100;
@@ -111,7 +111,7 @@ body {
   -moz-border-radius: 25px;
   -o-border-radius: 25px;
   font-size: 40px;
-  padding: 4px;
+  padding: 2px 4px 6px 4px;
 }
 #onlineUsers .phase ul.a-lot li div.userImage {
   width: 22px;
@@ -122,7 +122,7 @@ body {
   -moz-border-radius: 15px;
   -o-border-radius: 15px;
   font-size: 20px;
-  padding: 4px;
+  padding: 3px 4px 5px 4px;
 }
 
 #onlineUsers .phase ul li div.userName {

--- a/activity_streams/onlineUsers/onlineUsers.module.js
+++ b/activity_streams/onlineUsers/onlineUsers.module.js
@@ -1,11 +1,9 @@
 var app = angular.module('onlineUsersGadget', ['ngResource']);
 
 if (location.hostname === 'localhost' && location.port === '8080') {
-  var usedPort = '9091';
-} else if (location.port) {
-  var usedPort = location.port;
+  var hostToConnect = 'http://localhost:9091';
+} else {
+  var hostToConnect = 'http://graasp.eu';
 }
 
-var origin = location.protocol + '//' + location.hostname + (usedPort ? ':' + usedPort : '');
-
-var socket = io.connect(origin);
+var socket = io.connect(hostToConnect);

--- a/activity_streams/onlineUsers/onlineUsers.spaces.service.js
+++ b/activity_streams/onlineUsers/onlineUsers.spaces.service.js
@@ -1,4 +1,4 @@
-app.factory('Spaces', function ($resource, $http) {
+app.factory('Spaces', function () {
   'use strict';
 
   var space = {
@@ -11,7 +11,7 @@ app.factory('Spaces', function ($resource, $http) {
     ils.getIls(function(ils_space){
       cb(ils_space.id);
     });
-  }
+  };
 
   space.getPhases = function(cb) {
     ils.getIls(function(ils_space){
@@ -20,9 +20,9 @@ app.factory('Spaces', function ($resource, $http) {
 
         var phases = [];
         _.each(subspaces.list, function (subspace){
-          if (subspace.spaceType != null
-              && subspace.displayName != "About"
-              && subspace.displayName != "Vault") {
+          if (subspace.spaceType !== null &&
+              subspace.displayName != "About" &&
+              subspace.displayName != "Vault") {
             phases.push({
               id: subspace.id,
               name: subspace.displayName,
@@ -37,18 +37,18 @@ app.factory('Spaces', function ($resource, $http) {
 
   space.actions = function(cb) {
     ils.getIls(function(ils_space){
-      osapi.activitystreams.get({contextId: ils_space.id, contextType: "@space", "minutes":"60"})
+      osapi.activitystreams.get({contextId: ils_space.id, contextType: "@space", "minutes":"180"})
         .execute(function (actions) {
-        var accesses = _.filter(actions.list, function(action){ return action.verb == "accessed" });
-        var accessesByUser = _.toArray(_.groupBy(accesses, function(action){ return action.actor.id}));
+        var accesses = _.filter(actions.list, function(action){ return action.verb == "accessed"; });
+        var accessesByUser = _.toArray(_.groupBy(accesses, function(action){ return action.actor.id; }));
         var lastActionByUser = [];
         _.each(accessesByUser, function (userAccesses) {
-          var lastAction = _.last(_.sortBy(userAccesses, function(action){ return action.published }));
+          var lastAction = _.last(_.sortBy(userAccesses, function(action){ return action.published; }));
           lastActionByUser.push(lastAction);
         });
         cb(lastActionByUser);
       });
     });
-  }
+  };
   return space;
 });

--- a/activity_streams/time_spent/time_spent.module.js
+++ b/activity_streams/time_spent/time_spent.module.js
@@ -16,12 +16,10 @@ app.filter('numberFixedLen', function () {
 });
 
 if (location.hostname === 'localhost' && location.port === '8080') {
-  var usedPort = '9091';
-} else if (location.port) {
-  var usedPort = location.port;
+  var hostToConnect = 'http://localhost:9091';
+} else {
+  var hostToConnect = 'http://graasp.eu';
 }
 
-var origin = location.protocol + '//' + location.hostname + (usedPort ? ':' + usedPort : '');
-
-var socket = io.connect(origin);
+var socket = io.connect(hostToConnect);
 

--- a/activity_streams/time_spent/time_spent.spaces.service.js
+++ b/activity_streams/time_spent/time_spent.spaces.service.js
@@ -1,4 +1,4 @@
-app.factory('Spaces', function ($resource, $http) {
+app.factory('Spaces', function () {
   'use strict';
 
   var space = {
@@ -11,7 +11,7 @@ app.factory('Spaces', function ($resource, $http) {
     ils.getIls(function(ils_space){
       cb(ils_space.id);
     });
-  }
+  };
 
   space.getPhases = function(cb) {
     ils.getIls(function(ils_space){
@@ -20,13 +20,12 @@ app.factory('Spaces', function ($resource, $http) {
 
         var phases = [];
         _.each(subspaces.list, function (subspace){
-          if (subspace.spaceType != null
-              && subspace.displayName != "About"
-              && subspace.displayName != "Vault") {
+          if (subspace.spaceType !== null &&
+              subspace.displayName != "About" &&
+              subspace.displayName != "Vault") {
             phases.push({
               id: subspace.id,
-              name: subspace.displayName,
-              onlineUsers: []
+              name: subspace.displayName
             });
           }
         });
@@ -35,16 +34,16 @@ app.factory('Spaces', function ($resource, $http) {
     });
   };
 
-  space.getLastAccesses = function(cb) {
+  space.getActions = function(cb) {
     ils.getIls(function(ils_space){
       osapi.activitystreams.get({contextId: ils_space.id, contextType: "@space", "minutes":"180"})
         .execute(function (actions) {
-        var accesses = _.filter(actions.list, function(action){ return action.verb == "accessed" });
-        accesses = _.sortBy(accesses, function(action) { return action.published });
-        console.log(accesses);
+        var accesses = _.sortBy(actions.list, function(action) {
+          return action.published;
+        });
         cb(accesses);
       });
     });
-  }
+  };
   return space;
 });


### PR DESCRIPTION
- The socket now connects either to localhost:9091 or to graasp.eu and wait that the previous actions are loaded before listening.
- When connecting to the standalone view, the ILS emit the access action with target and object not referring to the same space. It is then more reliable to get the phase ID from the target instead of the object
- Improvement of the verification to avoid a user to appear several times in the online users gadget
- The first letter of the usernames are better vertically centered in the circles (when no gravatar)
- Code cleaning

Closes #222 #223
