### PR TITLE
Fix view problem for time spent gadget. Fixes #302

### DIFF
--- a/activity_streams/time_spent/gadget.xml
+++ b/activity_streams/time_spent/gadget.xml
@@ -15,7 +15,7 @@
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="time_spent.css" />
-    <link rel="stylesheet" href="datetimepicker.css"/>
+    <link rel="stylesheet" type="text/css" href="datetimepicker.css" />
 
     <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/headjs/1.0.3/head.min.js"></script>
     <script type="text/javascript">


### PR DESCRIPTION
`datetimepicker.css` was not loaded at all, but `time_spent.css` is. The only difference between the two declarations is that the `type` attribute is specified to `time_spent.css`. Therefore I added it to the declaration of `datetimepicker.css` which should now be loaded.

@MJRodriguezTriana Can you review please?