### PR TITLE
go-lab/lab (1)

### DIFF
--- a/go-lab/lab/cernland/cernland.xml
+++ b/go-lab/lab/cernland/cernland.xml
@@ -5,7 +5,7 @@
 	 	author_email="sten.govaerts+cernland@gmail.com"
 	 	description="CERNland is designed to teach children about CERN's research in an interactive way. It contains information about CERN, several videos and nine different games."
 	 	height="777"
-	 	screenshot="http://eatoneducationalinsights.edublogs.org/files/2010/12/cernland-1fw66oj.jpg"
+	 	screenshot="https://eatoneducationalinsights.edublogs.org/files/2010/12/cernland-1fw66oj.jpg"
 	 	thumbnail="">
 	 	<Require feature="opensocial-0.9" />
 	 </ModulePrefs>

--- a/go-lab/lab/faulkes/faulkes.xml
+++ b/go-lab/lab/faulkes/faulkes.xml
@@ -1,6 +1,6 @@
 <Module>
 	 <ModulePrefs title="Faulkes Telescope Project"
-	 	title_url="http://www.faulkes-telescope.com/"
+	 	title_url="https://www.faulkes-telescope.com/"
 	 	author="Sten Govaerts"
 	 	author_email="sten.govaerts+faulkes@gmail.com"
 	 	description="The Faulkes Telescope Project (FTP) is supported by the Dill Faulkes Educational Trust. It provides access to 1,500 hours of observing time on two 2-metre class telescopes located in Hawaii (Faulkes Telescope North in Hawaii) and Australia (Faulkes Telescope South in Australia). This time is dedicated to education and public outreach, mainly in the UK, but also for smaller, selected projects in Europe and the US.
@@ -8,7 +8,7 @@ FTP has operated a UK-wide educational programme since 2004, and currently works
 FTP operates a broad range of educational programmes, with a strong emphasis on teacher training and engaging students with “real science”. A variety of research projects are currently being run on the FTs, with schools often participating in the role of data gatherers, particularly in long-term monitoring or short-term intensive studies or Target of Opportunity requests for transient objects (e.g. GRBs, supernovae, NEOs or X-ray systems in outburst).
 The project also provides extensive educational materials which can be accessed and downloaded free of charge from their educational resources website. These resources include astronomy video tutorials, online astronomy training, paper-based documents for use in the classroom, and pre-packaged data from the telescopes to use with the exercises detailed online."
 	 	height="720"
-	 	screenshot="http://www.faulkes.com/dfet/images/images/ft_low.jpg"
+	 	screenshot="https://www.faulkes.com/dfet/images/images/ft_low.jpg"
 	 	thumbnail="">
 	 </ModulePrefs>
 	 <Content type="html">
@@ -22,7 +22,7 @@ The project also provides extensive educational materials which can be accessed 
 		//load frame
 		function loadFrame()
 		{
-			var srcString = "http://www.faulkes-telescope.com/";
+			var srcString = "https://www.faulkes-telescope.com/";
 			var width = "900";
 			var height = "720";
 			$('container').innerHTML = '<iframe frameborder="0" width="'+width+'" height="'+height+'" src="'+srcString+'"></iframe>';

--- a/go-lab/lab/hypatia/hypatia-java.xml
+++ b/go-lab/lab/hypatia/hypatia-java.xml
@@ -19,7 +19,7 @@
 		//load frame
 		function loadFrame()
 		{
-			$('container').innerHTML = '<embed id="HYPATIA" type="application/x-java-applet;version=1.6" width="870" height="980" archive="HypatiaApplet.jar, AbsoluteLayout.jar, jas-aida.jar, jas-aida-dev.jar, jas-freehep-base.jar, jas-freehep-hep.jar, jas-jas-plotter.jar" code="Hypatia.HypatiaApplet" pluginspage="http://java.com/download/" codebase="http://hypatia.iasa.gr/applet" layout="full" classloader_cache="false" languagefile="language_en">';
+			$('container').innerHTML = '<embed id="HYPATIA" type="application/x-java-applet;version=1.6" width="870" height="980" archive="HypatiaApplet.jar, AbsoluteLayout.jar, jas-aida.jar, jas-aida-dev.jar, jas-freehep-base.jar, jas-freehep-hep.jar, jas-jas-plotter.jar" code="Hypatia.HypatiaApplet" pluginspage="https://java.com/download/" codebase="http://hypatia.iasa.gr/applet" layout="full" classloader_cache="false" languagefile="language_en">';
 		}
 		
 		gadgets.util.registerOnLoadHandler(loadFrame);


### PR DESCRIPTION
go-lab/lab/dreamLabs
go-lab/lab/cernland
go-lab/lab/faulkes
go-lab/lab/foucault-pendulum
go-lab/lab/galaxycrash
go-lab/lab/hypatia
go-lab/lab/lhcgame
go-lab/lab/longjump

Could not migrate dreamLabs: "https://create.nyu.edu" has an invalid cert.
Could not migrate cernland: "https://www.cernland.net" has an invalid cert.
Migrate faulkes but "https://www.faulkes-telescope.com/" has some issue w/ the cert.
Could not migrate foucault-pendulum: "https://www.3dtrainingdesign.co.uk/" is not available.
Could not migrate galaxycrash: "https://burro.cwru.edu" has an invalid cert.
Could not migrate hypatia: "https://hypatia.iasa.gr" and "https://195.134.89.89" is not available.
Could not migrate lhcgame: "https://www.cernland.net" has an invalid cert.
Could not migrate longjump: "http://sim01.cti.ac.at" (http only) is not available.

close #424